### PR TITLE
Remove newline characters from JSON

### DIFF
--- a/R/python.assign.R
+++ b/R/python.assign.R
@@ -6,6 +6,9 @@ python.assign <- function( var.name, value ){
 
     #value <- toJSON( value )
     value <- toJSON( value, collapse = "" )
+    
+    # Sometimes toJSON introduces newlines that disturb the python interpreter
+    value <- gsub("\n", "", value)
 
     # Creating the call
 


### PR DESCRIPTION
Thanks for this nice package!

In some cases (did not figure out when and when not), toJSON leads to representations like

```
> toJSON(x_2)
[1] "[ [\n \"Scenario\",\n\"Waterbody\", ....
```

instead of

```
> toJSON(x_1)
[1] "[ [ \"Scenario\", \"Waterbody\", ...
```

which makes python.assign fail with the message

```
SyntaxError: EOL while scanning string literal
```

This can be avoided by substituting the newline characters in the JSON string before it is passed to the Python interpreter.

I am not clear what the difference between the code in this github project and the r-forge project is, this also applies to the code on r-forge. I only submitted the fix here, as it is easier on github.
